### PR TITLE
added support for mixcloud embed

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ const soundcloud = require('./providers/soundcloud');
 const spotify = require('./providers/spotify');
 const vimeo = require('./providers/vimeo');
 const youtube = require('./providers/youtube');
-const providers = [soundcloud, spotify, vimeo, youtube];
+const mixcloud = require('./providers/mixcloud');
+const providers = [soundcloud, spotify, vimeo, youtube, mixcloud];
 
 const RequestError = createError('RequestError');
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "vimeo",
     "soundcloud",
     "spotify",
-    "embed"
+    "embed",
+    "mixcloud"
   ],
   "author": "Steffen Strätz",
   "license": "MIT",

--- a/providers/mixcloud.js
+++ b/providers/mixcloud.js
@@ -1,0 +1,12 @@
+const apiUrl = 'https://www.mixcloud.com/oembed';
+
+const regExp = [
+  /https?:\/\/(?:www\.)?mixcloud\.com\/.+feed=(.*)/i,
+  /(https?:\/\/((?:www\.)?mixcloud\.com\/(.*)))/i,
+];
+
+function transform(match) {
+  return match[1].replace('%3A//', '://').replace('http:', 'https:');
+}
+
+module.exports = { apiUrl, regExp, transform };

--- a/test/providers.js
+++ b/test/providers.js
@@ -159,3 +159,25 @@ describe('Youtube', () => {
       .to.be.eventually.fulfilled;
   });
 });
+
+describe("Mixcloud", () => {
+  const apiUrl = "https://www.mixcloud.com/oembed";
+  const matchUrl =
+    "https://www.mixcloud.com/plxplxplx/plx-live-09-77-2017-no-advice-sssichtbeton";
+  const client = new MockClient(apiUrl, matchUrl);
+  const oEmbed = embedify.create({ client });
+
+  it("should match URL 1", () => {
+    const url =
+      "https://www.mixcloud.com/plxplxplx/plx-live-09-77-2017-no-advice-sssichtbeton";
+
+    return expect(oEmbed.get(url)).to.be.eventually.fulfilled;
+  });
+
+  it("should match URL 2", () => {
+    const url =
+      "https://www.mixcloud.com/widget/iframe/?hide_cover=1&feed=https://www.mixcloud.com/plxplxplx/plx-live-09-77-2017-no-advice-sssichtbeton";
+
+    return expect(oEmbed.get(url)).to.be.eventually.fulfilled;
+  });
+});


### PR DESCRIPTION
Added a provider to support embeds from https://www.mixcloud.com

Should support both
```
https://www.mixcloud.com/plxplxplx/plx-live-09-77-2017-no-advice-sssichtbeton/
https://www.mixcloud.com/widget/iframe/?hide_cover=1&feed=https://www.mixcloud.com/plxplxplx/plx-live-09-77-2017-no-advice-sssichtbeton

```
Their documentation covers the oembed endpoint.
https://www.mixcloud.com/developers/